### PR TITLE
support python3

### DIFF
--- a/sixel/__init__.py
+++ b/sixel/__init__.py
@@ -28,8 +28,8 @@ import optparse
 import select
 import logging
 
-from cellsize import CellSizeDetector
-from sixel import SixelWriter
+from .cellsize import CellSizeDetector
+from .sixel import SixelWriter
 
 license_text = """
 Copyright (C) 2012-2014  Hayaki Saito <user@zuse.jp>
@@ -154,7 +154,7 @@ def main():
     options, args = parser.parse_args()
 
     if options.version:
-        print license_text
+        print(license_text)
         sys.exit(0)
 
     rcdir = os.path.join(os.getenv("HOME"), ".pysixel")

--- a/sixel/converter.py
+++ b/sixel/converter.py
@@ -18,6 +18,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # ***** END LICENSE BLOCK *****
 
+import sys
+if sys.version_info[0] == 3:
+    xrange = range
+del sys
+
 
 class SixelConverter:
 

--- a/sixel/sixel.py
+++ b/sixel/sixel.py
@@ -23,9 +23,9 @@ import os
 import logging
 try:
     from sixel_cimpl import SixelConverter
-except ImportError, e:
+except ImportError as e:
     logging.exception(e)
-    from converter import SixelConverter
+    from .converter import SixelConverter
 
 
 class SixelWriter:


### PR DESCRIPTION
change to be compatible with python3
- relative import
- print function
- xrange is obsolete
- except `as` statement(maybe python2.6+)
