### PR TITLE
Update for python 3.8

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,7 @@
 
+2021-02-09 Rolv Erlend Bredesen <rolv.bredesen@gmail.com>
+    * Python3.8 support: Prefixed exc_traceback, exc_value, and exctype with prefix <cur>
+	
 2014-01-26 Hayaki Saito <user@zuse.jp>
 
     * Use alternative C-implemented module if possible

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 
 2021-02-09 Rolv Erlend Bredesen <rolv.bredesen@gmail.com>
-    * Python3.8 support: Prefixed exc_traceback, exc_value, and exctype with prefix <cur>
+    * Python3.8 support: Prefixed exc_traceback, exc_value, and exc_type with prefix <cur>
 	
 2014-01-26 Hayaki Saito <user@zuse.jp>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
+2022-01-01
+    
+    * Recursion error for python3.9 not resolved
+    
+2022-01-01 Rolv Erlend Bredesen <rolv.bredesen@gmail.com>
 
+    * Bugfix python3: sixelconv console script
+    
 2021-02-09 Rolv Erlend Bredesen <rolv.bredesen@gmail.com>
+
     * Python3.8 support: Prefixed exc_traceback, exc_value, and exc_type with prefix <cur>
 	
 2014-01-26 Hayaki Saito <user@zuse.jp>

--- a/sixel/__init__.py
+++ b/sixel/__init__.py
@@ -54,6 +54,9 @@ def _filenize(f):
 
     mode = os.fstat(f.fileno()).st_mode
     if stat.S_ISFIFO(mode) or os.isatty(f.fileno()):
+        if sys.version_info.major == 3:
+            import io
+            return io.StringIO(f.read())
         try:
             from cStringIO import StringIO
         except ImportError:

--- a/sixel/sixel_cimpl.c
+++ b/sixel/sixel_cimpl.c
@@ -2452,9 +2452,9 @@ static PyObject *__pyx_pf_11sixel_cimpl_14SixelConverter_4__write_palette_sectio
     } else {
       __pyx_t_3 = __pyx_t_5(__pyx_t_2);
       if (unlikely(!__pyx_t_3)) {
-        PyObject* exc_type = PyErr_Occurred();
-        if (exc_type) {
-          if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
+        PyObject* curexc_type = PyErr_Occurred();
+        if (curexc_type) {
+          if (likely(curexc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(curexc_type, PyExc_StopIteration))) PyErr_Clear();
           else {__pyx_filename = __pyx_f[0]; __pyx_lineno = 99; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
         }
         break;
@@ -2909,9 +2909,9 @@ static PyObject *__pyx_pf_11sixel_cimpl_14SixelConverter_35__write_body_without_
     } else {
       __pyx_t_5 = __pyx_t_7(__pyx_t_4);
       if (unlikely(!__pyx_t_5)) {
-        PyObject* exc_type = PyErr_Occurred();
-        if (exc_type) {
-          if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
+        PyObject* curexc_type = PyErr_Occurred();
+        if (curexc_type) {
+          if (likely(curexc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(curexc_type, PyExc_StopIteration))) PyErr_Clear();
           else {__pyx_filename = __pyx_f[0]; __pyx_lineno = 129; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
         }
         break;
@@ -3008,9 +3008,9 @@ static PyObject *__pyx_pf_11sixel_cimpl_14SixelConverter_35__write_body_without_
       } else {
         __pyx_t_8 = __pyx_t_10(__pyx_t_5);
         if (unlikely(!__pyx_t_8)) {
-          PyObject* exc_type = PyErr_Occurred();
-          if (exc_type) {
-            if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
+          PyObject* curexc_type = PyErr_Occurred();
+          if (curexc_type) {
+            if (likely(curexc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(curexc_type, PyExc_StopIteration))) PyErr_Clear();
             else {__pyx_filename = __pyx_f[0]; __pyx_lineno = 133; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
           }
           break;
@@ -3352,9 +3352,9 @@ static PyObject *__pyx_pf_11sixel_cimpl_14SixelConverter_6__write_body_without_a
     } else {
       __pyx_t_2 = __pyx_t_5(__pyx_t_3);
       if (unlikely(!__pyx_t_2)) {
-        PyObject* exc_type = PyErr_Occurred();
-        if (exc_type) {
-          if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
+        PyObject* curexc_type = PyErr_Occurred();
+        if (curexc_type) {
+          if (likely(curexc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(curexc_type, PyExc_StopIteration))) PyErr_Clear();
           else {__pyx_filename = __pyx_f[0]; __pyx_lineno = 107; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
         }
         break;
@@ -3563,9 +3563,9 @@ static PyObject *__pyx_pf_11sixel_cimpl_14SixelConverter_6__write_body_without_a
     } else {
       __pyx_t_1 = __pyx_t_5(__pyx_t_6);
       if (unlikely(!__pyx_t_1)) {
-        PyObject* exc_type = PyErr_Occurred();
-        if (exc_type) {
-          if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
+        PyObject* curexc_type = PyErr_Occurred();
+        if (curexc_type) {
+          if (likely(curexc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(curexc_type, PyExc_StopIteration))) PyErr_Clear();
           else {__pyx_filename = __pyx_f[0]; __pyx_lineno = 115; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
         }
         break;
@@ -3807,9 +3807,9 @@ static PyObject *__pyx_pf_11sixel_cimpl_14SixelConverter_6__write_body_without_a
         } else {
           __pyx_t_2 = __pyx_t_13(__pyx_t_9);
           if (unlikely(!__pyx_t_2)) {
-            PyObject* exc_type = PyErr_Occurred();
-            if (exc_type) {
-              if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
+            PyObject* curexc_type = PyErr_Occurred();
+            if (curexc_type) {
+              if (likely(curexc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(curexc_type, PyExc_StopIteration))) PyErr_Clear();
               else {__pyx_filename = __pyx_f[0]; __pyx_lineno = 152; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
             }
             break;
@@ -4229,9 +4229,9 @@ static PyObject *__pyx_pf_11sixel_cimpl_14SixelConverter_8__write_body_without_a
     } else {
       __pyx_t_3 = __pyx_t_5(__pyx_t_2);
       if (unlikely(!__pyx_t_3)) {
-        PyObject* exc_type = PyErr_Occurred();
-        if (exc_type) {
-          if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
+        PyObject* curexc_type = PyErr_Occurred();
+        if (curexc_type) {
+          if (likely(curexc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(curexc_type, PyExc_StopIteration))) PyErr_Clear();
           else {__pyx_filename = __pyx_f[0]; __pyx_lineno = 164; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
         }
         break;
@@ -4333,9 +4333,9 @@ static PyObject *__pyx_pf_11sixel_cimpl_14SixelConverter_8__write_body_without_a
       } else {
         __pyx_t_6 = __pyx_t_8(__pyx_t_1);
         if (unlikely(!__pyx_t_6)) {
-          PyObject* exc_type = PyErr_Occurred();
-          if (exc_type) {
-            if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
+          PyObject* curexc_type = PyErr_Occurred();
+          if (curexc_type) {
+            if (likely(curexc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(curexc_type, PyExc_StopIteration))) PyErr_Clear();
             else {__pyx_filename = __pyx_f[0]; __pyx_lineno = 169; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
           }
           break;
@@ -5341,9 +5341,9 @@ static PyObject *__pyx_pf_11sixel_cimpl_14SixelConverter_10__write_body_with_alp
     } else {
       __pyx_t_3 = __pyx_t_5(__pyx_t_2);
       if (unlikely(!__pyx_t_3)) {
-        PyObject* exc_type = PyErr_Occurred();
-        if (exc_type) {
-          if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
+        PyObject* curexc_type = PyErr_Occurred();
+        if (curexc_type) {
+          if (likely(curexc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(curexc_type, PyExc_StopIteration))) PyErr_Clear();
           else {__pyx_filename = __pyx_f[0]; __pyx_lineno = 221; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
         }
         break;
@@ -5460,9 +5460,9 @@ static PyObject *__pyx_pf_11sixel_cimpl_14SixelConverter_10__write_body_with_alp
       } else {
         __pyx_t_6 = __pyx_t_8(__pyx_t_3);
         if (unlikely(!__pyx_t_6)) {
-          PyObject* exc_type = PyErr_Occurred();
-          if (exc_type) {
-            if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
+          PyObject* curexc_type = PyErr_Occurred();
+          if (curexc_type) {
+            if (likely(curexc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(curexc_type, PyExc_StopIteration))) PyErr_Clear();
             else {__pyx_filename = __pyx_f[0]; __pyx_lineno = 227; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
           }
           break;
@@ -7672,7 +7672,9 @@ PyMODINIT_FUNC PyInit_sixel_cimpl(void)
   /*--- Function export code ---*/
   /*--- Type init code ---*/
   if (PyType_Ready(&__pyx_type_11sixel_cimpl___pyx_scope_struct____write_body_without_alphathreshold) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 106; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-  __pyx_type_11sixel_cimpl___pyx_scope_struct____write_body_without_alphathreshold.tp_print = 0;
+  //  __pyx_type_11sixel_cimpl___pyx_scope_struct____write_body_without_alphathreshold.tp_print = 0;
+    __pyx_type_11sixel_cimpl___pyx_scope_struct____write_body_without_alphathreshold.tp_vectorcall_offset = 0;
+   
   __pyx_ptype_11sixel_cimpl___pyx_scope_struct____write_body_without_alphathreshold = &__pyx_type_11sixel_cimpl___pyx_scope_struct____write_body_without_alphathreshold;
   /*--- Type import code ---*/
   /*--- Variable import code ---*/
@@ -8091,9 +8093,9 @@ static PyObject* __Pyx_ImportFrom(PyObject* module, PyObject* name) {
 static CYTHON_INLINE void __Pyx_ExceptionSave(PyObject **type, PyObject **value, PyObject **tb) {
 #if CYTHON_COMPILING_IN_CPYTHON
     PyThreadState *tstate = PyThreadState_GET();
-    *type = tstate->exc_type;
-    *value = tstate->exc_value;
-    *tb = tstate->exc_traceback;
+    *type = tstate->curexc_type;
+    *value = tstate->curexc_value;
+    *tb = tstate->curexc_traceback;
     Py_XINCREF(*type);
     Py_XINCREF(*value);
     Py_XINCREF(*tb);
@@ -8105,12 +8107,12 @@ static void __Pyx_ExceptionReset(PyObject *type, PyObject *value, PyObject *tb) 
 #if CYTHON_COMPILING_IN_CPYTHON
     PyObject *tmp_type, *tmp_value, *tmp_tb;
     PyThreadState *tstate = PyThreadState_GET();
-    tmp_type = tstate->exc_type;
-    tmp_value = tstate->exc_value;
-    tmp_tb = tstate->exc_traceback;
-    tstate->exc_type = type;
-    tstate->exc_value = value;
-    tstate->exc_traceback = tb;
+    tmp_type = tstate->curexc_type;
+    tmp_value = tstate->curexc_value;
+    tmp_tb = tstate->curexc_traceback;
+    tstate->curexc_type = type;
+    tstate->curexc_value = value;
+    tstate->curexc_traceback = tb;
     Py_XDECREF(tmp_type);
     Py_XDECREF(tmp_value);
     Py_XDECREF(tmp_tb);
@@ -8153,12 +8155,12 @@ static int __Pyx_GetException(PyObject **type, PyObject **value, PyObject **tb) 
     *value = local_value;
     *tb = local_tb;
 #if CYTHON_COMPILING_IN_CPYTHON
-    tmp_type = tstate->exc_type;
-    tmp_value = tstate->exc_value;
-    tmp_tb = tstate->exc_traceback;
-    tstate->exc_type = local_type;
-    tstate->exc_value = local_value;
-    tstate->exc_traceback = local_tb;
+    tmp_type = tstate->curexc_type;
+    tmp_value = tstate->curexc_value;
+    tmp_tb = tstate->curexc_traceback;
+    tstate->curexc_type = local_type;
+    tstate->curexc_value = local_value;
+    tstate->curexc_traceback = local_tb;
     Py_XDECREF(tmp_type);
     Py_XDECREF(tmp_value);
     Py_XDECREF(tmp_tb);
@@ -8177,12 +8179,12 @@ bad:
 }
 
 static CYTHON_INLINE void __Pyx_RaiseTooManyValuesError(Py_ssize_t expected) {
-    PyErr_Format(PyExc_ValueError,
+    PyErr_Format(PyExc_ValueError, 
                  "too many values to unpack (expected %" CYTHON_FORMAT_SSIZE_T "d)", expected);
 }
 
 static CYTHON_INLINE void __Pyx_RaiseNeedMoreValuesError(Py_ssize_t index) {
-    PyErr_Format(PyExc_ValueError,
+  PyErr_Format(PyExc_ValueError,
                  "need more than %" CYTHON_FORMAT_SSIZE_T "d value%.1s to unpack",
                  index, (index == 1) ? "" : "s");
 }
@@ -8190,17 +8192,17 @@ static CYTHON_INLINE void __Pyx_RaiseNeedMoreValuesError(Py_ssize_t index) {
 static CYTHON_INLINE int __Pyx_IterFinish(void) {
 #if CYTHON_COMPILING_IN_CPYTHON
     PyThreadState *tstate = PyThreadState_GET();
-    PyObject* exc_type = tstate->curexc_type;
-    if (unlikely(exc_type)) {
-        if (likely(exc_type == PyExc_StopIteration) || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration)) {
-            PyObject *exc_value, *exc_tb;
-            exc_value = tstate->curexc_value;
+    PyObject* curexc_type = tstate->curexc_type;
+    if (unlikely(curexc_type)) {
+        if (likely(curexc_type == PyExc_StopIteration) || PyErr_GivenExceptionMatches(curexc_type, PyExc_StopIteration)) {
+            PyObject *curexc_value, *exc_tb;
+            curexc_value = tstate->curexc_value;
             exc_tb = tstate->curexc_traceback;
             tstate->curexc_type = 0;
             tstate->curexc_value = 0;
             tstate->curexc_traceback = 0;
-            Py_DECREF(exc_type);
-            Py_XDECREF(exc_value);
+            Py_DECREF(curexc_type);
+            Py_XDECREF(curexc_value);
             Py_XDECREF(exc_tb);
             return 0;
         } else {
@@ -8951,12 +8953,12 @@ static CYTHON_INLINE void __Pyx_ExceptionSwap(PyObject **type, PyObject **value,
     PyObject *tmp_type, *tmp_value, *tmp_tb;
 #if CYTHON_COMPILING_IN_CPYTHON
     PyThreadState *tstate = PyThreadState_GET();
-    tmp_type = tstate->exc_type;
-    tmp_value = tstate->exc_value;
-    tmp_tb = tstate->exc_traceback;
-    tstate->exc_type = *type;
-    tstate->exc_value = *value;
-    tstate->exc_traceback = *tb;
+    tmp_type = tstate->curexc_type;
+    tmp_value = tstate->curexc_value;
+    tmp_tb = tstate->curexc_traceback;
+    tstate->curexc_type = *type;
+    tstate->curexc_value = *value;
+    tstate->curexc_traceback = *tb;
 #else
     PyErr_GetExcInfo(&tmp_type, &tmp_value, &tmp_tb);
     PyErr_SetExcInfo(*type, *value, *tb);


### PR DESCRIPTION
Fixed compilation errros by renaming tp_print to tp_vectorcall_offset and added <cur> prefix to tstate -> type, value and traceback
tstate->curexc_type = type;
tstate->curexc_value = value;
tstate->curexc_traceback = tb;
